### PR TITLE
Rename downloaded images with hashes

### DIFF
--- a/_data/data.js
+++ b/_data/data.js
@@ -6,7 +6,6 @@ const Path = require('path');
 const Parser = require('rss-parser');
 const Axios = require('axios');
 const Sharp = require('sharp');
-const { copyFile } = require('fs');
 
 const PLATFORMS = {
   TYPLOG: 'Typlog',

--- a/_data/data.js
+++ b/_data/data.js
@@ -202,7 +202,7 @@ const downloadImage = async function (url, file) {
     const path = Path.join(IMAGE_DIRECTORY, filename);
     const virtualPath = Path.join(IMAGE_PATH, filename);
 
-    await FS.copyFile(oldFilePath, path)
+    return await FS.copyFile(oldFilePath, path)
       .then((res) => {
         console.log(`Image copyed: ${path}`);
         return Promise.resolve({
@@ -216,8 +216,6 @@ const downloadImage = async function (url, file) {
         );
         return Promise.reject(error);
       });
-
-    return;
   }
 
   const response = await Axios({


### PR DESCRIPTION
Cache downloaded image URLs and resized image pathnames in two Maps.
Copy images if the same images are used.
Resolve #45
@CatChen 