### PR TITLE
Fixed rss-parser getting 406 from Ximalaya

### DIFF
--- a/_data/data.js
+++ b/_data/data.js
@@ -73,7 +73,15 @@ const fetchFeed = async function (platform, url) {
   const label = `${platform} feed downloaded (${url})`;
   try {
     console.time(label);
-    const parser = new Parser();
+    const parser =
+      platform === PLATFORMS.XIMALAYA
+        ? new Parser({
+            headers: {
+              // rss-parser's default 'Accept: application/rss+xml' triggers Ximalaya 406
+              Accept: '*/*',
+            },
+          })
+        : new Parser();
     const result = await parser.parseURL(url);
     console.log(
       `${platform} feed downloaded (${url}): ${result.items.length} episodes`,


### PR DESCRIPTION
Ximalaya's server responds with status code 406 when there's `Accept: application/rss+xml` in the request header, which is the default for `rss-parser`. I have to override it with `Accept: */*` for Ximalaya. This should fix #233.